### PR TITLE
fix: 多路径封面缓存、NFO解析容错、封面/海报关键词匹配、README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ data 文件夹结构示例：
 data/
 ├── 文件夹目录1/
 │   ├── 作品文件夹1/
-│   │   ├── poster.jpg    # 封面（或 *ps.jpg / *ps.png 等）
-│   │   ├── fanart.jpg    # 海报（或 *pl.jpg / *pl.png 等）
+│   │   ├── poster.jpg    # 封面（或 *ps.* / 文件名含 poster，如 MKMP-393-C-poster.jpg）
+│   │   ├── fanart.jpg    # 海报（或 *pl.* / 文件名含 fanart，如 MKMP-393-C-fanart.jpg）
 │   │   ├── xxx.nfo       # 元数据文件（任意 .nfo 后缀均可）
 │   │   └── video.mp4     # 视频文件（可选）
 │   └── ...
@@ -117,7 +117,7 @@ data/
 ```
 
 - **NFO**：支持任意文件名的 `.nfo` 文件，不限于 `movie.nfo`
-- **封面/海报**：支持 `poster.*` / `fanart.*`，以及以 `ps` / `pl` 结尾的图片（如 `gmab008ps.jpg`、`gmab008pl.png`）
+- **封面/海报**：优先识别以 `ps`/`pl` 结尾的图片；其次按关键词匹配，文件名含 `poster` 为封面、含 `fanart` 为海报（支持 `poster.jpg`、`番号-分类-poster.jpg` 等）
 - **识别码**：NFO 中可使用 `<uniqueid>` 或 `<num>` 标签，编辑时按原格式更新
 
 ### 主要功能

--- a/electron/src/config/database.js
+++ b/electron/src/config/database.js
@@ -62,6 +62,13 @@ async function initDatabase() {
       } catch (walError) {
         console.warn('启用 WAL 模式失败，使用默认模式:', walError.message);
       }
+      // 设置 busy_timeout：锁等待 30 秒，避免扫描时与前端查询冲突导致 SQLITE_BUSY
+      try {
+        await sequelize.query('PRAGMA busy_timeout = 30000');
+        console.log('SQLite busy_timeout 已设置为 30000ms');
+      } catch (busyError) {
+        console.warn('设置 busy_timeout 失败:', busyError.message);
+      }
     } catch (authError) {
       console.error('数据库连接失败:', authError);
       console.error('错误详情:', authError.message);

--- a/electron/src/utils/fileUtils.js
+++ b/electron/src/utils/fileUtils.js
@@ -26,9 +26,9 @@ async function getImagePaths(folderPath) {
 
   // 支持的图片扩展名
   const imageExtensions = ['.jpg', '.jpeg', '.png', '.webp'];
-  // 使用优先级控制：ps/pl 命名优先，其次是 poster/fanart 默认命名
-  // poster: 2 = *ps.*, 1 = poster.*, 0 = 未匹配
-  // fanart: 2 = *pl.*, 1 = fanart.*, 0 = 未匹配
+  // 使用优先级控制：ps/pl 命名优先，其次是含 poster/fanart 关键词的命名（支持刮削器生成的 番号-分类-poster.jpg 等）
+  // poster: 2 = *ps.*, 1 = 文件名含 poster, 0 = 未匹配
+  // fanart: 2 = *pl.*, 1 = 文件名含 fanart, 0 = 未匹配
   let posterPriority = 0;
   let fanartPriority = 0;
 
@@ -41,26 +41,26 @@ async function getImagePaths(folderPath) {
     const lowerFile = file.toLowerCase();
     const nameWithoutExt = path.basename(lowerFile, ext);
 
-    // 封面图：优先识别 *ps.(jpg|png|webp...)，其次是 poster.(jpg|png...)
+    // 封面图：优先识别 *ps.(jpg|png|webp...)，其次为文件名含 poster 关键词（如 MKMP-393-C-poster）
     if (nameWithoutExt.endsWith('ps')) {
       if (posterPriority < 2) {
         posterPriority = 2;
         poster = path.join(folderPath, file);
       }
-    } else if (nameWithoutExt === 'poster') {
+    } else if (nameWithoutExt.includes('poster')) {
       if (posterPriority < 1) {
         posterPriority = 1;
         poster = path.join(folderPath, file);
       }
     }
 
-    // 海报图 / 背景图：优先识别 *pl.(jpg|png|webp...)，其次是 fanart.(jpg|png...)
+    // 海报图 / 背景图：优先识别 *pl.(jpg|png|webp...)，其次为文件名含 fanart 关键词（如 MKMP-393-C-fanart）
     if (nameWithoutExt.endsWith('pl')) {
       if (fanartPriority < 2) {
         fanartPriority = 2;
         fanart = path.join(folderPath, file);
       }
-    } else if (nameWithoutExt === 'fanart') {
+    } else if (nameWithoutExt.includes('fanart')) {
       if (fanartPriority < 1) {
         fanartPriority = 1;
         fanart = path.join(folderPath, file);

--- a/frontend/src/components/MovieListLayout.vue
+++ b/frontend/src/components/MovieListLayout.vue
@@ -72,7 +72,7 @@
         >
           <div class="movie-poster">
             <el-image
-              :src="imageCache?.[movie?.poster_path] || ''"
+              :src="imageCache?.[getImageCacheKey(movie?.poster_path, movie?.data_path_index)] || ''"
               fit="contain"
               style="width: 100%; height: 100%;"
               :lazy="true"
@@ -114,6 +114,7 @@
 <script setup>
 import { computed } from 'vue';
 import { VideoPlay } from '@element-plus/icons-vue';
+import { getImageCacheKey } from '../utils/imageLoader';
 
 const props = defineProps({
   loading: { type: Boolean, default: false },

--- a/frontend/src/views/ActorMovieList.vue
+++ b/frontend/src/views/ActorMovieList.vue
@@ -38,7 +38,7 @@ import { VideoPlay } from '@element-plus/icons-vue';
 import MovieListLayout from '../components/MovieListLayout.vue';
 import { savePageState, getPageState, saveScrollPosition, restoreScrollPosition, clearScrollPosition } from '../utils/pageState';
 import { withLoadingOptimization } from '../utils/loadingOptimizer';
-import { loadImagesBatch, pauseBackgroundLoading } from '../utils/imageLoader';
+import { loadImagesBatch, pauseBackgroundLoading, getImageCacheKey } from '../utils/imageLoader';
 
 const router = useRouter();
 const route = useRoute();
@@ -156,14 +156,15 @@ const loadMoviesRaw = async () => {
 const loadMovies = withLoadingOptimization(loadMoviesRaw);
 
 const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
-  if (!posterPath || imageCache.value[posterPath]) {
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
+  if (!posterPath || imageCache.value[cacheKey]) {
     return;
   }
   
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
     }
   } catch (error) {
     console.error('加载图片失败:', error);
@@ -173,16 +174,17 @@ const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
 const getPosterUrl = async (posterPath, dataPathIndex = 0) => {
   if (!posterPath) return '';
   
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
   // 检查缓存
-  if (imageCache.value[posterPath]) {
-    return imageCache.value[posterPath];
+  if (imageCache.value[cacheKey]) {
+    return imageCache.value[cacheKey];
   }
   
   // 异步加载图片
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
       return imageUrl;
     }
   } catch (error) {

--- a/frontend/src/views/DirectorMovieList.vue
+++ b/frontend/src/views/DirectorMovieList.vue
@@ -38,7 +38,7 @@ import { VideoPlay } from '@element-plus/icons-vue';
 import MovieListLayout from '../components/MovieListLayout.vue';
 import { savePageState, getPageState, saveScrollPosition, restoreScrollPosition } from '../utils/pageState';
 import { withLoadingOptimization } from '../utils/loadingOptimizer';
-import { loadImagesBatch, pauseBackgroundLoading } from '../utils/imageLoader';
+import { loadImagesBatch, pauseBackgroundLoading, getImageCacheKey } from '../utils/imageLoader';
 
 const router = useRouter();
 const route = useRoute();
@@ -105,14 +105,15 @@ const loadMoviesRaw = async () => {
 const loadMovies = withLoadingOptimization(loadMoviesRaw);
 
 const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
-  if (!posterPath || imageCache.value[posterPath]) {
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
+  if (!posterPath || imageCache.value[cacheKey]) {
     return;
   }
   
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
     }
   } catch (error) {
     console.error('加载图片失败:', error);

--- a/frontend/src/views/GenreMovieList.vue
+++ b/frontend/src/views/GenreMovieList.vue
@@ -38,7 +38,7 @@ import { VideoPlay } from '@element-plus/icons-vue';
 import MovieListLayout from '../components/MovieListLayout.vue';
 import { savePageState, getPageState, saveScrollPosition, restoreScrollPosition, clearScrollPosition } from '../utils/pageState';
 import { withLoadingOptimization } from '../utils/loadingOptimizer';
-import { loadImagesBatch, pauseBackgroundLoading } from '../utils/imageLoader';
+import { loadImagesBatch, pauseBackgroundLoading, getImageCacheKey } from '../utils/imageLoader';
 
 const router = useRouter();
 const route = useRoute();
@@ -100,14 +100,15 @@ const loadMoviesRaw = async () => {
 const loadMovies = withLoadingOptimization(loadMoviesRaw);
 
 const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
-  if (!posterPath || imageCache.value[posterPath]) {
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
+  if (!posterPath || imageCache.value[cacheKey]) {
     return;
   }
   
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
     }
   } catch (error) {
     console.error('加载图片失败:', error);

--- a/frontend/src/views/SearchResults.vue
+++ b/frontend/src/views/SearchResults.vue
@@ -42,6 +42,7 @@ import { ref, onMounted, onBeforeMount, computed, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { ElMessage } from 'element-plus';
 import MovieListLayout from '../components/MovieListLayout.vue';
+import { getImageCacheKey } from '../utils/imageLoader';
 
 const router = useRouter();
 const route = useRoute();
@@ -130,14 +131,15 @@ const loadSearchResults = async () => {
 };
 
 const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
-  if (!posterPath || imageCache.value[posterPath]) {
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
+  if (!posterPath || imageCache.value[cacheKey]) {
     return;
   }
   
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
     }
   } catch (error) {
     console.error('加载图片失败:', error);

--- a/frontend/src/views/SeriesList.vue
+++ b/frontend/src/views/SeriesList.vue
@@ -33,6 +33,7 @@ import { ref, onMounted, computed } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { ElMessage } from 'element-plus';
 import MovieListLayout from '../components/MovieListLayout.vue';
+import { getImageCacheKey } from '../utils/imageLoader';
 
 const router = useRouter();
 const route = useRoute();
@@ -64,14 +65,15 @@ const loadMovies = async () => {
 };
 
 const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
-  if (!posterPath || imageCache.value[posterPath]) {
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
+  if (!posterPath || imageCache.value[cacheKey]) {
     return;
   }
   
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
     }
   } catch (error) {
     console.error('加载图片失败:', error);

--- a/frontend/src/views/StudioMovieList.vue
+++ b/frontend/src/views/StudioMovieList.vue
@@ -38,7 +38,7 @@ import { VideoPlay } from '@element-plus/icons-vue';
 import MovieListLayout from '../components/MovieListLayout.vue';
 import { savePageState, getPageState, saveScrollPosition, restoreScrollPosition } from '../utils/pageState';
 import { withLoadingOptimization } from '../utils/loadingOptimizer';
-import { loadImagesBatch, pauseBackgroundLoading } from '../utils/imageLoader';
+import { loadImagesBatch, pauseBackgroundLoading, getImageCacheKey } from '../utils/imageLoader';
 
 const router = useRouter();
 const route = useRoute();
@@ -105,14 +105,15 @@ const loadMoviesRaw = async () => {
 const loadMovies = withLoadingOptimization(loadMoviesRaw);
 
 const loadMovieImage = async (posterPath, dataPathIndex = 0) => {
-  if (!posterPath || imageCache.value[posterPath]) {
+  const cacheKey = getImageCacheKey(posterPath, dataPathIndex);
+  if (!posterPath || imageCache.value[cacheKey]) {
     return;
   }
   
   try {
     const imageUrl = await window.electronAPI?.movies?.getImage?.(posterPath, dataPathIndex);
     if (imageUrl) {
-      imageCache.value[posterPath] = imageUrl;
+      imageCache.value[cacheKey] = imageUrl;
     }
   } catch (error) {
     console.error('加载图片失败:', error);


### PR DESCRIPTION
- 图片缓存 key 改为 data_path_index:poster_path，修复多数据路径下封面互相覆盖及排序后错乱
- NFO 解析预处理：转义内容中 </script>/<script>，数字开头标签名改为合法形式，避免 Unexpected close tag / Unencoded < 报错
- 封面/海报识别改为关键词匹配（文件名含 poster/fanart），支持番号-分类-poster.jpg 等刮削器命名
- README 更新封面/海报说明与 data 目录示例

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes NFO XML preprocessing and front-end image caching semantics across multiple list views, which could impact parsing fidelity and image rendering. Database `busy_timeout` is low risk but affects runtime behavior under concurrent access.
> 
> **Overview**
> **Improves correctness and resilience in media ingestion and UI rendering.** NFO parsing now pre-sanitizes problematic XML by escaping embedded `<script>` fragments and rewriting invalid numeric-leading tag names, reducing parse failures on malformed files.
> 
> **Fixes multi-library poster caching collisions.** Frontend image cache keys are changed to `data_path_index:poster_path` via a shared `getImageCacheKey`, and all list/grid views are updated to read/write the cache with this key to prevent covers from overwriting each other across multiple data roots.
> 
> **Broadens cover/art filename matching and reduces SQLite lock errors.** Image discovery now falls back to keyword matching for filenames containing `poster`/`fanart` (in addition to `*ps`/`*pl` priority), SQLite initializes `PRAGMA busy_timeout=30000`, and `README` is updated to document the new poster/fanart naming rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c45b3dd918a25f4b4b9d3b3ddea2357f22a300f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->